### PR TITLE
fix: return a one-time agent token on paid wallet joins

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,8 @@ challenge; it does not prove that the payer is authorized to command a particula
   `Tact-Agent-Token` header so it cannot collide with MPP authentication.
 - AgentCash paid joins use the payer DID from a cryptographically verified MPP credential. The
   wallet identity is normalized, stored as a `principal_identity`, and granted only the tank it
-  paid to join.
+  paid to join. Because non-paid routes never see a payment challenge, the join response also
+  mints an agent token for the same principal and returns it once as `agentToken`.
 - Wallets: identities attached to a principal and useful as payment sources; never the sole
   principal record.
 - Delegation: explicit game/player grants with scope, expiry, and revocation. A human can give

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Humans, built-in bots, and external agents share the same actions, rules, and pu
 The canonical machine contract is `/openapi.json`. Agent commands require the latest game
 version plus a UUID command ID and idempotency key. A human can provision an agent token from
 the profile menu; agents send it as `Tact-Agent-Token` or a bearer token. Paid MPP joins can use
-the verified payer wallet as agent identity and do not need a separate API key.
+the verified payer wallet as agent identity and do not need a separate API key; the join response
+returns a one-time `agentToken` the agent sends as `Tact-Agent-Token` on every later command.
 
 ```bash
 npx agentcash@latest discover https://tact.wtf

--- a/apps/web/src/app/api/v1/games/[gameId]/join/route.ts
+++ b/apps/web/src/app/api/v1/games/[gameId]/join/route.ts
@@ -4,6 +4,7 @@ import { withMppCharge } from "@/lib/payments";
 import { ApiError, commandRejectionResponse, problemResponse } from "@/lib/server/api-error";
 import { getGame, joinGame } from "@/lib/server/game-service";
 import {
+  issueWalletAgentToken,
   requireRequestPrincipal,
   resolveRequestPrincipal,
   resolveVerifiedMppWalletPrincipal,
@@ -51,7 +52,17 @@ export async function POST(
             if (result.command.status === "rejected") {
               return commandRejectionResponse(result.command);
             }
-            return Response.json(result, { headers: { "cache-control": "no-store" } });
+            // Wallet payers have no other credential for /commands, so hand
+            // them a bearer token bound to the same principal. Replays mint a
+            // fresh token because the original is only ever returned once.
+            const agentToken =
+              !existingPrincipal && payment.payer
+                ? await issueWalletAgentToken(authenticated)
+                : undefined;
+            return Response.json(
+              agentToken ? { ...result, agentToken } : result,
+              { headers: { "cache-control": "no-store" } },
+            );
           } catch (error) {
             return problemResponse(error);
           }

--- a/apps/web/src/lib/openapi.ts
+++ b/apps/web/src/lib/openapi.ts
@@ -37,7 +37,7 @@ export const openApiDocument = {
       "A continuous-time hex strategy and diplomacy game where humans and autonomous agents compete, cooperate, and negotiate on the same battlefield.",
     contact: { name: "Tact", url: "https://tact.wtf" },
     "x-guidance":
-      "List lobbies with GET /api/v1/games, inspect one, then POST its /join endpoint. Paid games use Tempo MPP and the verified payer wallet becomes the agent identity, so AgentCash can join without an API key. Every command needs a UUID commandId, an idempotencyKey, and the latest expectedVersion; on 409, refetch the game. Read /api/v1/rulesets/legacy-v2 for mechanics and /legal-actions before choosing a command.",
+      "List lobbies with GET /api/v1/games, inspect one, then POST its /join endpoint. Paid games use Tempo MPP and the verified payer wallet becomes the agent identity, so AgentCash can join without an API key; the join response then includes a one-time agentToken to send as Tact-Agent-Token on every later command. Every command needs a UUID commandId, an idempotencyKey, and the latest expectedVersion; on 409, refetch the game. Read /api/v1/rulesets/legacy-v2 for mechanics and /legal-actions before choosing a command.",
   },
   servers: [{ url: "/", description: "Tact" }],
   tags: [
@@ -246,7 +246,7 @@ export const openApiDocument = {
         operationId: "joinGame",
         summary: "Join a game; paid lobbies settle a Tempo MPP charge",
         description:
-          "Free games require a player or agent identity. For paid games, a verified MPP payer DID can be used as the agent identity.",
+          "Free games require a player or agent identity. For paid games, a verified MPP payer DID can be used as the agent identity; the response then returns a one-time agentToken for authenticating later commands.",
         parameters: [gameIdParameter],
         "x-payment-info": {
           price: { mode: "dynamic", currency: "USD", min: "0", max: maxEntryPrice },
@@ -268,7 +268,7 @@ export const openApiDocument = {
           },
         },
         responses: {
-          "200": { description: "Joined; includes Payment-Receipt for paid games", content: json({ $ref: "#/components/schemas/CommandResult" }) },
+          "200": { description: "Joined; includes Payment-Receipt for paid games and agentToken for wallet-identified joins", content: json({ $ref: "#/components/schemas/JoinResult" }) },
           "400": problem,
           "401": problem,
           "402": { description: "MPP challenge; price comes from the selected game" },
@@ -617,6 +617,21 @@ export const openApiDocument = {
         type: "object",
         required: ["command", "game"],
         properties: { command: { $ref: "#/components/schemas/CommandReceipt" }, game: { $ref: "#/components/schemas/Game" }, bot: { type: "object" } },
+      },
+      JoinResult: {
+        allOf: [
+          { $ref: "#/components/schemas/CommandResult" },
+          {
+            type: "object",
+            properties: {
+              agentToken: {
+                type: "string",
+                description:
+                  "Present when a verified MPP payer joined without an existing identity. Returned once; send it as Tact-Agent-Token (or a bearer token) on subsequent requests.",
+              },
+            },
+          },
+        ],
       },
       GameEvent: {
         type: "object",

--- a/apps/web/src/lib/server/identity.ts
+++ b/apps/web/src/lib/server/identity.ts
@@ -1,4 +1,5 @@
 import {
+  attachPrincipalIdentity,
   findPrincipalByIdentity,
   hashJson,
   resolveOrCreatePrincipal,
@@ -97,20 +98,42 @@ export async function issueAgentToken(input: {
   if (input.creator.kind !== "human") {
     throw new ApiError(403, "human_session_required", "Forbidden", "Only a human session can create agent tokens.");
   }
+  const { token, identity } = await mintAgentTokenIdentity();
+  const principal = await resolveOrCreatePrincipal({
+    identity,
+    principalKind: "agent",
+    displayName: input.displayName,
+  });
+  return { principal, token };
+}
+
+/**
+ * Grants an MPP wallet principal a bearer credential for non-paid routes such
+ * as /commands, which never see a payment challenge. The raw token is returned
+ * exactly once; callers that lose it can replay the paid join to mint another.
+ */
+export async function issueWalletAgentToken(principal: PrincipalView): Promise<string> {
+  const { token, identity } = await mintAgentTokenIdentity();
+  await attachPrincipalIdentity({ principalId: principal.id, identity });
+  return token;
+}
+
+async function mintAgentTokenIdentity(): Promise<{
+  token: string;
+  identity: IdentityDescriptor;
+}> {
   const random = crypto.getRandomValues(new Uint8Array(32));
   const token = `tact_agent_${toBase64Url(random)}`;
   const tokenHash = await hashJson(token);
-  const principal = await resolveOrCreatePrincipal({
+  return {
+    token,
     identity: {
       kind: "agent_token",
       issuer: AGENT_ISSUER,
       subject: tokenHash,
       credentialHash: tokenHash,
     },
-    principalKind: "agent",
-    displayName: input.displayName,
-  });
-  return { principal, token };
+  };
 }
 
 /** Adapter target for the Neon Auth SDK once installed by the auth/UI slice. */

--- a/packages/db/src/principal-repository.ts
+++ b/packages/db/src/principal-repository.ts
@@ -125,6 +125,19 @@ export async function resolveOrCreatePrincipal(input: {
   });
 }
 
+export async function attachPrincipalIdentity(input: {
+  principalId: string;
+  identity: IdentityDescriptor;
+}): Promise<void> {
+  await getDatabase().insert(principalIdentities).values({
+    principalId: input.principalId,
+    kind: input.identity.kind,
+    issuer: input.identity.issuer,
+    subject: input.identity.subject,
+    credentialHash: input.identity.credentialHash,
+  });
+}
+
 export async function updatePrincipalDisplayName(
   principalId: string,
   displayName: string,


### PR DESCRIPTION
Fixes the main finding in #50: MPP wallet agents can join a paid game but can never issue a command afterward. `/commands` only authenticates `Tact-Agent-Token` / bearer tokens / session cookies, and a payer-DID principal has no way to obtain any of them — the tank is permanently frozen (see the two zombie tanks in prod game `913c235d-7ee1-4931-a3f8-4a51e48691e6`).

## Approach

When a verified MPP payer joins without an existing identity, mint a `tact_agent_*` token **bound to the same wallet principal** and return it once in the join response as `agentToken`. The agent sends it as `Tact-Agent-Token` on every later request — the exact credential path `/commands` already supports, so no new auth surface, no change to the payment protocol, and delegation/actor rules keep working unchanged.

```
POST /join (402 → pay → 200)
{ "command": {...}, "game": {...}, "agentToken": "tact_agent_…" }
```

- `packages/db`: `attachPrincipalIdentity` — insert an additional identity row for an existing principal.
- `identity.ts`: `issueWalletAgentToken(principal)`; token minting shared with `issueAgentToken` via `mintAgentTokenIdentity()`.
- Join route: issue the token only for paid joins where the principal came from `payment.payer` (token/cookie joins are unchanged). Replays mint a fresh token since the raw token is only ever returned once — that's the retry path for an agent that lost the first response.
- OpenAPI (`JoinResult` schema), `x-guidance`, README, and ARCHITECTURE updated to document the flow.

## Notes

- Finding 2 in #50 (www 308 breaking MPP) looks already handled by 2248918 / 364a960.
- Finding 3 (idempotent join replays settle a fresh MPP charge each retry) is **not** addressed here — it needs either a pre-charge replay lookup (impossible for wallet joiners, whose identity comes from the payment itself) or refund handling, so leaving it to a follow-up.

`pnpm lint && pnpm typecheck && pnpm test && pnpm build` all pass on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
